### PR TITLE
Fixes PHP errors when field is used on existing entries

### DIFF
--- a/src/Field.php
+++ b/src/Field.php
@@ -145,7 +145,7 @@ JS, [
     {
         if (is_string($value) && !empty($value)) {
             $value = Json::decodeIfJson($value);
-        } elseif ($value === null && $this->isFresh($element) && is_array($this->slots)) {
+        } elseif ($value === null && is_array($this->slots)) {
             $value = [];
         }
 

--- a/src/Field.php
+++ b/src/Field.php
@@ -145,11 +145,11 @@ JS, [
     {
         if (is_string($value) && !empty($value)) {
             $value = Json::decodeIfJson($value);
+            ksort($value);
         } elseif ($value === null && is_array($this->slots)) {
             $value = [];
         }
 
-        ksort($value);
         $data = [];
 
         for ($day = 0; $day <= 6; $day++) {


### PR DESCRIPTION
### Description

I added a new Store Hours field to an entry type which was already being used by entries. `ksort` in `Field::normalizeValue()` was throwing an error.

### Related issues

n/a