### PR TITLE
add schema version to address a project-config validation change in craft 5.3.4

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -22,6 +22,11 @@ class Plugin extends \craft\base\Plugin
     /**
      * @inheritdoc
      */
+    public string $schemaVersion = '1.0.2';
+
+    /**
+     * @inheritdoc
+     */
     public function init()
     {
         parent::init();


### PR DESCRIPTION

### Description
This addresses issue #59 . Adds the schema property to the `Plugin` class so the project config can validate properly.

